### PR TITLE
Fix potential deadlock when using git-lfs

### DIFF
--- a/zest/releaser/utils.py
+++ b/zest/releaser/utils.py
@@ -745,8 +745,7 @@ def _subprocess_open(p, command, input_value, show_stderr):
     if input_value:
         i.write(input_value.encode(INPUT_ENCODING))
     i.close()
-    stdout_output = o.read()
-    stderr_output = e.read()
+    (stdout_output, stderr_output) = p.communicate()
     # We assume that the output from commands we're running is text.
     if not isinstance(stdout_output, six.text_type):
         stdout_output = stdout_output.decode(OUTPUT_ENCODING)


### PR DESCRIPTION
Use p.communicate() instead of of .read() on stderr/stdout directly as that seems to cause a deadlock with large outputs (or at least that is what I think happens).
Before this change zest.releaser would get stuck doing a clone of the repository, if the repository uses git-lfs.